### PR TITLE
feat(ngrx-ducks): add duckReducerFrom

### DIFF
--- a/ngrx/ducks/src/lib/reducer/reducer-from.ts
+++ b/ngrx/ducks/src/lib/reducer/reducer-from.ts
@@ -35,3 +35,9 @@ export function reducerFrom<T extends new () => InstanceType<T>>(
       : state;
   };
 }
+
+export function duckReducerFrom<T extends new () => InstanceType<T>>(
+  Token: T
+) {
+  return (state, action) => reducerFrom(Token)(state, action);
+}


### PR DESCRIPTION
There is no need to create an additional _reducer_ method for every `Duck`. The method **duckReducerFrom** can be used like this:

```ts
StoreModule.forFeature('counter', duckReducerFrom(Counter))
```

I did not want to change `reducerFrom` to be compatible with existing solutions. What do you think? I can create a separate file for it. See #10 for an [example](https://stackblitz.com/edit/ngrx-ducks-reducer?file=src%2Fapp%2Fstore%2Fduck-reducer-from.ts) where the function is created outside of **ngrx-ducks**.