### PR TITLE
Schematics improvements

### DIFF
--- a/ngrx/ducks-schematics/README.md
+++ b/ngrx/ducks-schematics/README.md
@@ -6,4 +6,13 @@ You get this package automatically if you install [@co-it/ngrx-ducks](https://ww
 
 | Command                                                                      | Description                            |
 | ---------------------------------------------------------------------------- | -------------------------------------- |
-| ng generate @co-it/ngrx-ducks:**ducks** <path/duck> **--project** \<project> | Create a duck in the desired directory |
+| ng generate @co-it/ngrx-ducks:**duck** <path/duck> | Create a duck in the desired directory |
+
+## Parameter
+
+| Parameter                                                                      | Description                            |
+| ---------------------------------------------------------------------------- | -------------------------------------- |
+| project | The name of the project. |
+| barrel | When true (the default) and not flat, creates a index.ts barrel file. |
+| flat | When true, creates files at the top level of the project. |
+| spec | When true (the default), generates a  \"spec.ts\" test file for the new Duck. |

--- a/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/__name@dasherize__.duck.ts.template
+++ b/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/__name@dasherize__.duck.ts.template
@@ -1,4 +1,9 @@
-import { Action, Ducksify, reducerFrom } from '@co-it/ngrx-ducks';
+import {
+  Action,
+  DucksifiedAction,
+  Ducksify,
+  reducerFrom
+} from '@co-it/ngrx-ducks';
 import { <%= classify(name) %>State } from './<%= dasherize(name) %>.state';
 
 @Ducksify<<%= classify(name) %>State>({
@@ -13,6 +18,9 @@ export class <%= classify(name) %> {
   }
 }
 
-export function <%= camelize(name) %>Reducer(state, action) {
+export function <%= camelize(name) %>Reducer(
+  state: <%= classify(name) %>State | undefined,
+  action: DucksifiedAction
+): <%= classify(name) %>State {
   return reducerFrom(<%= classify(name) %>)(state, action);
 }


### PR DESCRIPTION
- [x] Reducer Function needs to be typed
- [x] Allow creating a duck without passing `--project`, should work using `ng generate`
- [x] Document all available parameters for the generation command in the `README.md`

see #5 