### PR TITLE
feat(ducks-schematics): add effects + selectors option

### DIFF
--- a/ngrx/ducks-schematics/README.md
+++ b/ngrx/ducks-schematics/README.md
@@ -16,3 +16,4 @@ You get this package automatically if you install [@co-it/ngrx-ducks](https://ww
 | barrel | When true (the default) and not flat, creates a index.ts barrel file. |
 | flat | When true, creates files at the top level of the project. |
 | spec | When true (the default), generates a  \"spec.ts\" test file for the new Duck. |
+| effects | When true (the default), generates a  \"effects.ts\" test file for the effects of the new Duck. |

--- a/ngrx/ducks-schematics/README.md
+++ b/ngrx/ducks-schematics/README.md
@@ -17,4 +17,6 @@ You get this package automatically if you install [@co-it/ngrx-ducks](https://ww
 | flat | When true, creates files at the top level of the project. |
 | spec | When true (the default), generates a \"spec.ts\" test file for the new Duck. |
 | effects | When true (the default), generates an \"effects.ts\" file for the new Duck. |
+| module | The declaring NgModule for the effect (or nearest NgModule if omitted). |
+| skipImport | When true, does not import the effect into the owning NgModule. |
 | selectors | When true (the default), generates a \"selectors.ts\" file for the new Duck. |

--- a/ngrx/ducks-schematics/README.md
+++ b/ngrx/ducks-schematics/README.md
@@ -15,5 +15,6 @@ You get this package automatically if you install [@co-it/ngrx-ducks](https://ww
 | project | The name of the project. |
 | barrel | When true (the default) and not flat, creates a index.ts barrel file. |
 | flat | When true, creates files at the top level of the project. |
-| spec | When true (the default), generates a  \"spec.ts\" test file for the new Duck. |
-| effects | When true (the default), generates a  \"effects.ts\" test file for the effects of the new Duck. |
+| spec | When true (the default), generates a \"spec.ts\" test file for the new Duck. |
+| effects | When true (the default), generates an \"effects.ts\" file for the new Duck. |
+| selectors | When true (the default), generates a \"selectors.ts\" file for the new Duck. |

--- a/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/__name@dasherize__.duck.spec.ts.template
+++ b/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/__name@dasherize__.duck.spec.ts.template
@@ -10,7 +10,7 @@ describe('<%= classify(name) %>', () => {
     state = { data: 0 };
   });
 
-  it('should set count', () => {
+  it('should set data', () => {
     expect(duck.setData(state, 1).data).toBe(1);
   });
 });

--- a/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/__name@dasherize__.duck.ts.template
+++ b/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/__name@dasherize__.duck.ts.template
@@ -1,7 +1,8 @@
 import {
   Action,
   DucksifiedAction,
-  Ducksify,
+  Ducksify,<% if (effects) { %>
+  effect,<% } %>
   reducerFrom
 } from '@co-it/ngrx-ducks';
 import { <%= classify(name) %>State } from './<%= dasherize(name) %>.state';
@@ -11,7 +12,9 @@ import { <%= classify(name) %>State } from './<%= dasherize(name) %>.state';
     data: 0
   }
 })
-export class <%= classify(name) %> {
+export class <%= classify(name) %> {<% if (effects) { %>
+  readonly loadData = effect<number>('[<%= classify(name) %>] Sample effect');
+<% } %>
   @Action('[<%= classify(name) %>] Sample action type')
   setData(stateSlice: <%= classify(name) %>State, data: number): <%= classify(name) %>State {
     return { ...stateSlice, data };

--- a/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/__name@dasherize__.duck.ts.template
+++ b/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/__name@dasherize__.duck.ts.template
@@ -4,7 +4,8 @@ import {
   Ducksify,<% if (effects) { %>
   effect,<% } %>
   reducerFrom
-} from '@co-it/ngrx-ducks';
+} from '@co-it/ngrx-ducks';<% if (selectors) { %>
+import * as selectors from './<%= dasherize(name) %>.selectors';<% } %>
 import { <%= classify(name) %>State } from './<%= dasherize(name) %>.state';
 
 @Ducksify<<%= classify(name) %>State>({
@@ -12,7 +13,9 @@ import { <%= classify(name) %>State } from './<%= dasherize(name) %>.state';
     data: 0
   }
 })
-export class <%= classify(name) %> {<% if (effects) { %>
+export class <%= classify(name) %> {<% if (selectors) { %>
+  data$ = selectors.data;
+<% } %><% if (effects) { %>
   readonly loadData = effect<number>('[<%= classify(name) %>] Sample effect');
 <% } %>
   @Action('[<%= classify(name) %>] Sample action type')

--- a/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts.template
+++ b/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts.template
@@ -6,6 +6,11 @@ import { <%= classify(name) %> } from './<%= dasherize(name) %>.duck';
 
 @Injectable()
 export class <%= classify(name) %>Effects {
+  /**
+   * Generated example
+   *
+   * You may want to replace this Effect with your own implementation.
+   */
   @Effect()
   loadData = this.actions$.pipe(
     whereType(this.<%= camelize(name) %>.loadData),

--- a/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts.template
+++ b/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/__name@dasherize__.effects.ts.template
@@ -1,0 +1,20 @@
+import { Inject, Injectable } from '@angular/core';
+import { Duck, whereType } from '@co-it/ngrx-ducks';
+import { Actions, Effect } from '@ngrx/effects';
+import { delay, map } from 'rxjs/operators';
+import { <%= classify(name) %> } from './<%= dasherize(name) %>.duck';
+
+@Injectable()
+export class <%= classify(name) %>Effects {
+  @Effect()
+  loadData = this.actions$.pipe(
+    whereType(this.<%= camelize(name) %>.loadData),
+    delay(2000),
+    map(({ payload }) => this.<%= camelize(name) %>.setData.action(payload))
+  );
+
+  constructor(
+    private actions$: Actions,
+    @Inject(<%= classify(name) %>) private <%= camelize(name) %>: Duck<<%= classify(name) %>>
+  ) {}
+}

--- a/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/__name@dasherize__.selectors.ts.template
+++ b/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/__name@dasherize__.selectors.ts.template
@@ -1,0 +1,9 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { <%= classify(name) %>State } from './<%= dasherize(name) %>.state';
+
+const visit<%= classify(name) %> = createFeatureSelector<<%= classify(name) %>State>('<%= dasherize(name) %>');
+
+export const data = createSelector(
+  visit<%= classify(name) %>,
+  <%= camelize(name) %>State => <%= camelize(name) %>State.data
+);

--- a/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/index.ts.template
+++ b/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/index.ts.template
@@ -1,3 +1,4 @@
 export * from './<%= dasherize(name) %>.duck';<% if (effects) { %>
-export * from './<%= dasherize(name) %>.effects';<% } %>
+export * from './<%= dasherize(name) %>.effects';<% } %><% if (selectors) { %>
+export * from './<%= dasherize(name) %>.selectors';<% } %>
 export * from './<%= dasherize(name) %>.state';

--- a/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/index.ts.template
+++ b/ngrx/ducks-schematics/src/collection/duck/files/__name@dasherize@if-flat__/index.ts.template
@@ -1,2 +1,3 @@
-export * from './<%= dasherize(name) %>.duck';
+export * from './<%= dasherize(name) %>.duck';<% if (effects) { %>
+export * from './<%= dasherize(name) %>.effects';<% } %>
 export * from './<%= dasherize(name) %>.state';

--- a/ngrx/ducks-schematics/src/collection/duck/index.ts
+++ b/ngrx/ducks-schematics/src/collection/duck/index.ts
@@ -68,7 +68,8 @@ function addDeclarationToNgModule(options: DuckOptions): Rule {
       relativeEffectImportPath,
       `EffectsModule.forFeature([${strings.classify(
         options.name + 'Effects'
-      )}])`
+      )}])`,
+      'EffectsModule'
     );
     /**
      * add import for the EffectsModule

--- a/ngrx/ducks-schematics/src/collection/duck/index.ts
+++ b/ngrx/ducks-schematics/src/collection/duck/index.ts
@@ -29,6 +29,9 @@ export default function(options: DuckOptions): Rule {
       !options.effects
         ? filter(path => !path.endsWith('effects.ts.template'))
         : noop(),
+      !options.selectors
+        ? filter(path => !path.endsWith('selectors.ts.template'))
+        : noop(),
       applyTemplates({
         ...strings,
         'if-flat': (s: string) => (options.flat ? '' : s),

--- a/ngrx/ducks-schematics/src/collection/duck/index.ts
+++ b/ngrx/ducks-schematics/src/collection/duck/index.ts
@@ -1,8 +1,63 @@
-import { strings } from '@angular-devkit/core';
+import { normalize, strings } from '@angular-devkit/core';
 import { apply, applyTemplates, chain, filter, mergeWith, move, noop, Rule, SchematicsException, Tree, url } from '@angular-devkit/schematics';
+import * as ts from 'typescript';
+import { addSymbolToNgModuleMetadata, insertImport } from '../../utils/ast-utils';
+import { InsertChange } from '../../utils/change';
+import { buildRelativePath, findModuleFromOptions } from '../../utils/find-modules';
 import { parseName } from '../../utils/parse-name';
 import { buildDefaultPath, getProject } from '../../utils/project';
 import { Schema as DuckOptions } from './schema';
+
+function addDeclarationToNgModule(options: DuckOptions): Rule {
+  return (host: Tree) => {
+    if (options.skipImport || !options.module || !options.effects) {
+      return host;
+    }
+
+    const modulePath = options.module;
+
+    const text = host.read(modulePath);
+    if (text === null) {
+      throw new SchematicsException(`File ${modulePath} does not exist.`);
+    }
+    const sourceText = text.toString('utf-8');
+    const source = ts.createSourceFile(modulePath, sourceText, ts.ScriptTarget.Latest, true);
+
+    const importEffectPath = normalize(
+      `/${options.path}/`
+      + (options.flat ? '' : strings.dasherize(options.name) + '/')
+      + strings.dasherize(options.name)
+      + '.effects',
+    );
+    const relativeEffectImportPath = buildRelativePath(modulePath, importEffectPath);
+    /**
+     * add import for the duck Effects class 
+     * + add EffectsModule.forFeature() to NgModule imports
+     */
+    const changes = addSymbolToNgModuleMetadata(
+      source, 
+      modulePath, 
+      'imports', 
+      strings.classify(`${options.name}Effects`), 
+      relativeEffectImportPath,
+      `EffectsModule.forFeature([${strings.classify(options.name + 'Effects')}])`
+    );
+    /**
+     * add import for the EffectsModule
+     */
+    changes.push(insertImport(source, modulePath, 'EffectsModule', '@ngrx/effects'));
+
+    const recorder = host.beginUpdate(modulePath);
+    for (const change of changes) {
+      if (change instanceof InsertChange) {
+        recorder.insertLeft(change.pos, change.toAdd);
+      }
+    }
+    host.commitUpdate(recorder);
+
+    return host;
+  };
+}
 
 export default function(options: DuckOptions): Rule {
   return (host: Tree) => {
@@ -13,6 +68,10 @@ export default function(options: DuckOptions): Rule {
 
     if (!options.path) {
       options.path = buildDefaultPath(project);
+    }
+
+    if (options.effects && !options.skipImport) {
+      options.module = findModuleFromOptions(host, options);
     }
 
     const parsedPath = parseName(options.path, options.name);
@@ -40,6 +99,9 @@ export default function(options: DuckOptions): Rule {
       move(parsedPath.path)
     ]);
 
-    return chain([mergeWith(templateSource)]);
+    return chain([
+      addDeclarationToNgModule(options),
+      mergeWith(templateSource)
+    ]);
   };
 }

--- a/ngrx/ducks-schematics/src/collection/duck/index.ts
+++ b/ngrx/ducks-schematics/src/collection/duck/index.ts
@@ -1,9 +1,27 @@
 import { normalize, strings } from '@angular-devkit/core';
-import { apply, applyTemplates, chain, filter, mergeWith, move, noop, Rule, SchematicsException, Tree, url } from '@angular-devkit/schematics';
+import {
+  apply,
+  applyTemplates,
+  chain,
+  filter,
+  mergeWith,
+  move,
+  noop,
+  Rule,
+  SchematicsException,
+  Tree,
+  url
+} from '@angular-devkit/schematics';
 import * as ts from 'typescript';
-import { addSymbolToNgModuleMetadata, insertImport } from '../../utils/ast-utils';
+import {
+  addSymbolToNgModuleMetadata,
+  insertImport
+} from '../../utils/ast-utils';
 import { InsertChange } from '../../utils/change';
-import { buildRelativePath, findModuleFromOptions } from '../../utils/find-modules';
+import {
+  buildRelativePath,
+  findModuleFromOptions
+} from '../../utils/find-modules';
 import { parseName } from '../../utils/parse-name';
 import { buildDefaultPath, getProject } from '../../utils/project';
 import { Schema as DuckOptions } from './schema';
@@ -21,31 +39,43 @@ function addDeclarationToNgModule(options: DuckOptions): Rule {
       throw new SchematicsException(`File ${modulePath} does not exist.`);
     }
     const sourceText = text.toString('utf-8');
-    const source = ts.createSourceFile(modulePath, sourceText, ts.ScriptTarget.Latest, true);
+    const source = ts.createSourceFile(
+      modulePath,
+      sourceText,
+      ts.ScriptTarget.Latest,
+      true
+    );
 
     const importEffectPath = normalize(
-      `/${options.path}/`
-      + (options.flat ? '' : strings.dasherize(options.name) + '/')
-      + strings.dasherize(options.name)
-      + '.effects',
+      `/${options.path}/` +
+        (options.flat ? '' : strings.dasherize(options.name) + '/') +
+        strings.dasherize(options.name) +
+        '.effects'
     );
-    const relativeEffectImportPath = buildRelativePath(modulePath, importEffectPath);
+    const relativeEffectImportPath = buildRelativePath(
+      modulePath,
+      importEffectPath
+    );
     /**
-     * add import for the duck Effects class 
+     * add import for the duck Effects class
      * + add EffectsModule.forFeature() to NgModule imports
      */
     const changes = addSymbolToNgModuleMetadata(
-      source, 
-      modulePath, 
-      'imports', 
-      strings.classify(`${options.name}Effects`), 
+      source,
+      modulePath,
+      'imports',
+      strings.classify(`${options.name}Effects`),
       relativeEffectImportPath,
-      `EffectsModule.forFeature([${strings.classify(options.name + 'Effects')}])`
+      `EffectsModule.forFeature([${strings.classify(
+        options.name + 'Effects'
+      )}])`
     );
     /**
      * add import for the EffectsModule
      */
-    changes.push(insertImport(source, modulePath, 'EffectsModule', '@ngrx/effects'));
+    changes.push(
+      insertImport(source, modulePath, 'EffectsModule', '@ngrx/effects')
+    );
 
     const recorder = host.beginUpdate(modulePath);
     for (const change of changes) {

--- a/ngrx/ducks-schematics/src/collection/duck/index.ts
+++ b/ngrx/ducks-schematics/src/collection/duck/index.ts
@@ -1,17 +1,5 @@
 import { strings } from '@angular-devkit/core';
-import {
-  apply,
-  applyTemplates,
-  chain,
-  filter,
-  mergeWith,
-  move,
-  noop,
-  Rule,
-  SchematicsException,
-  Tree,
-  url
-} from '@angular-devkit/schematics';
+import { apply, applyTemplates, chain, filter, mergeWith, move, noop, Rule, SchematicsException, Tree, url } from '@angular-devkit/schematics';
 import { parseName } from '../../utils/parse-name';
 import { buildDefaultPath, getProject } from '../../utils/project';
 import { Schema as DuckOptions } from './schema';
@@ -37,6 +25,9 @@ export default function(options: DuckOptions): Rule {
         : noop(),
       !options.barrel || options.flat
         ? filter(path => !path.endsWith('index.ts.template'))
+        : noop(),
+      !options.effects
+        ? filter(path => !path.endsWith('effects.ts.template'))
         : noop(),
       applyTemplates({
         ...strings,

--- a/ngrx/ducks-schematics/src/collection/duck/schema.json
+++ b/ngrx/ducks-schematics/src/collection/duck/schema.json
@@ -46,8 +46,14 @@
     "effects": {
       "type": "boolean",
       "default": true,
-      "description": "When true (the default), generates an  \"effects.ts\" test file for the effects of the new Duck.",
-      "x-prompt": "Do you want to create an effects file?"
+      "description": "When true (the default), generates an  \"effects.ts\" file for the new Duck.",
+      "x-prompt": "Do you want to create effects?"
+    },
+    "selectors": {
+      "type": "boolean",
+      "default": true,
+      "description": "When true (the default), generates a  \"selectors.ts\" file for the new Duck.",
+      "x-prompt": "Do you want to create selectors?"
     }
   },
   "required": ["name"]

--- a/ngrx/ducks-schematics/src/collection/duck/schema.json
+++ b/ngrx/ducks-schematics/src/collection/duck/schema.json
@@ -49,6 +49,16 @@
       "description": "When true (the default), generates an  \"effects.ts\" file for the new Duck.",
       "x-prompt": "Do you want to create effects?"
     },
+    "module":  {
+      "type": "string",
+      "description": "The declaring NgModule for the effect.",
+      "alias": "m"
+    },
+    "skipImport": {
+      "type": "boolean",
+      "description": "When true, does not import the effect into the owning NgModule.",
+      "default": false
+    },
     "selectors": {
       "type": "boolean",
       "default": true,

--- a/ngrx/ducks-schematics/src/collection/duck/schema.json
+++ b/ngrx/ducks-schematics/src/collection/duck/schema.json
@@ -30,7 +30,8 @@
     "barrel": {
       "type": "boolean",
       "default": true,
-      "description": "When true (the default) and not flat, creates a index.ts barrel file."
+      "description": "When true (the default) and not flat, creates a index.ts barrel file.",
+      "x-prompt": "Do you want to create a barrel (index.ts) file?"
     },
     "flat": {
       "type": "boolean",
@@ -39,8 +40,14 @@
     },
     "spec": {
       "type": "boolean",
-      "description": "When true (the default), generates a  \"spec.ts\" test file for the new Duck.",
-      "default": true
+      "default": true,
+      "description": "When true (the default), generates a  \"spec.ts\" test file for the new Duck."
+    },
+    "effects": {
+      "type": "boolean",
+      "default": true,
+      "description": "When true (the default), generates an  \"effects.ts\" test file for the effects of the new Duck.",
+      "x-prompt": "Do you want to create an effects file?"
     }
   },
   "required": ["name"]

--- a/ngrx/ducks-schematics/src/collection/duck/schema.ts
+++ b/ngrx/ducks-schematics/src/collection/duck/schema.ts
@@ -5,4 +5,5 @@ export interface Schema {
   barrel: boolean;
   flat: boolean;
   spec: boolean;
+  effects: boolean;
 }

--- a/ngrx/ducks-schematics/src/collection/duck/schema.ts
+++ b/ngrx/ducks-schematics/src/collection/duck/schema.ts
@@ -6,4 +6,5 @@ export interface Schema {
   flat: boolean;
   spec: boolean;
   effects: boolean;
+  selectors: boolean;
 }

--- a/ngrx/ducks-schematics/src/collection/duck/schema.ts
+++ b/ngrx/ducks-schematics/src/collection/duck/schema.ts
@@ -1,3 +1,5 @@
+import { Path } from "@angular-devkit/core";
+
 export interface Schema {
   name: string;
   path: string;
@@ -6,5 +8,7 @@ export interface Schema {
   flat: boolean;
   spec: boolean;
   effects: boolean;
+  module: Path | undefined;
+  skipImport: boolean;
   selectors: boolean;
 }

--- a/ngrx/ducks-schematics/src/utils/ast-utils.ts
+++ b/ngrx/ducks-schematics/src/utils/ast-utils.ts
@@ -1,0 +1,574 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+import { Change, InsertChange, NoopChange } from './change';
+
+
+/**
+ * Add Import `import { symbolName } from fileName` if the import doesn't exit
+ * already. Assumes fileToEdit can be resolved and accessed.
+ * @param fileToEdit (file we want to add import to)
+ * @param symbolName (item to import)
+ * @param fileName (path to the file)
+ * @param isDefault (if true, import follows style for importing default exports)
+ * @return Change
+ */
+export function insertImport(source: ts.SourceFile, fileToEdit: string, symbolName: string,
+                             fileName: string, isDefault = false): Change {
+  const rootNode = source;
+  const allImports = findNodes(rootNode, ts.SyntaxKind.ImportDeclaration);
+
+  // get nodes that map to import statements from the file fileName
+  const relevantImports = allImports.filter(node => {
+    // StringLiteral of the ImportDeclaration is the import file (fileName in this case).
+    const importFiles = node.getChildren()
+      .filter(child => child.kind === ts.SyntaxKind.StringLiteral)
+      .map(n => (n as ts.StringLiteral).text);
+
+    return importFiles.filter(file => file === fileName).length === 1;
+  });
+
+  if (relevantImports.length > 0) {
+    let importsAsterisk = false;
+    // imports from import file
+    const imports: ts.Node[] = [];
+    relevantImports.forEach(n => {
+      Array.prototype.push.apply(imports, findNodes(n, ts.SyntaxKind.Identifier));
+      if (findNodes(n, ts.SyntaxKind.AsteriskToken).length > 0) {
+        importsAsterisk = true;
+      }
+    });
+
+    // if imports * from fileName, don't add symbolName
+    if (importsAsterisk) {
+      return new NoopChange();
+    }
+
+    const importTextNodes = imports.filter(n => (n as ts.Identifier).text === symbolName);
+
+    // insert import if it's not there
+    if (importTextNodes.length === 0) {
+      const fallbackPos =
+        findNodes(relevantImports[0], ts.SyntaxKind.CloseBraceToken)[0].getStart() ||
+        findNodes(relevantImports[0], ts.SyntaxKind.FromKeyword)[0].getStart();
+
+      return insertAfterLastOccurrence(imports, `, ${symbolName}`, fileToEdit, fallbackPos);
+    }
+
+    return new NoopChange();
+  }
+
+  // no such import declaration exists
+  const useStrict = findNodes(rootNode, ts.SyntaxKind.StringLiteral)
+    .filter((n: ts.StringLiteral) => n.text === 'use strict');
+  let fallbackPos = 0;
+  if (useStrict.length > 0) {
+    fallbackPos = useStrict[0].end;
+  }
+  const open = isDefault ? '' : '{ ';
+  const close = isDefault ? '' : ' }';
+  // if there are no imports or 'use strict' statement, insert import at beginning of file
+  const insertAtBeginning = allImports.length === 0 && useStrict.length === 0;
+  const separator = insertAtBeginning ? '' : ';\n';
+  const toInsert = `${separator}import ${open}${symbolName}${close}` +
+    ` from '${fileName}'${insertAtBeginning ? ';\n' : ''}`;
+
+  return insertAfterLastOccurrence(
+    allImports,
+    toInsert,
+    fileToEdit,
+    fallbackPos,
+    ts.SyntaxKind.StringLiteral,
+  );
+}
+
+
+/**
+ * Find all nodes from the AST in the subtree of node of SyntaxKind kind.
+ * @param node
+ * @param kind
+ * @param max The maximum number of items to return.
+ * @return all nodes of kind, or [] if none is found
+ */
+export function findNodes(node: ts.Node, kind: ts.SyntaxKind, max = Infinity): ts.Node[] {
+  if (!node || max == 0) {
+    return [];
+  }
+
+  const arr: ts.Node[] = [];
+  if (node.kind === kind) {
+    arr.push(node);
+    max--;
+  }
+  if (max > 0) {
+    for (const child of node.getChildren()) {
+      findNodes(child, kind, max).forEach(node => {
+        if (max > 0) {
+          arr.push(node);
+        }
+        max--;
+      });
+
+      if (max <= 0) {
+        break;
+      }
+    }
+  }
+
+  return arr;
+}
+
+
+/**
+ * Get all the nodes from a source.
+ * @param sourceFile The source file object.
+ * @returns {Observable<ts.Node>} An observable of all the nodes in the source.
+ */
+export function getSourceNodes(sourceFile: ts.SourceFile): ts.Node[] {
+  const nodes: ts.Node[] = [sourceFile];
+  const result = [];
+
+  while (nodes.length > 0) {
+    const node = nodes.shift();
+
+    if (node) {
+      result.push(node);
+      if (node.getChildCount(sourceFile) >= 0) {
+        nodes.unshift(...node.getChildren());
+      }
+    }
+  }
+
+  return result;
+}
+
+export function findNode(node: ts.Node, kind: ts.SyntaxKind, text: string): ts.Node | null {
+  if (node.kind === kind && node.getText() === text) {
+    // throw new Error(node.getText());
+    return node;
+  }
+
+  let foundNode: ts.Node | null = null;
+  ts.forEachChild(node, childNode => {
+    foundNode = foundNode || findNode(childNode, kind, text);
+  });
+
+  return foundNode;
+}
+
+
+/**
+ * Helper for sorting nodes.
+ * @return function to sort nodes in increasing order of position in sourceFile
+ */
+function nodesByPosition(first: ts.Node, second: ts.Node): number {
+  return first.getStart() - second.getStart();
+}
+
+
+/**
+ * Insert `toInsert` after the last occurence of `ts.SyntaxKind[nodes[i].kind]`
+ * or after the last of occurence of `syntaxKind` if the last occurence is a sub child
+ * of ts.SyntaxKind[nodes[i].kind] and save the changes in file.
+ *
+ * @param nodes insert after the last occurence of nodes
+ * @param toInsert string to insert
+ * @param file file to insert changes into
+ * @param fallbackPos position to insert if toInsert happens to be the first occurence
+ * @param syntaxKind the ts.SyntaxKind of the subchildren to insert after
+ * @return Change instance
+ * @throw Error if toInsert is first occurence but fall back is not set
+ */
+export function insertAfterLastOccurrence(nodes: ts.Node[],
+                                          toInsert: string,
+                                          file: string,
+                                          fallbackPos: number,
+                                          syntaxKind?: ts.SyntaxKind): Change {
+  // sort() has a side effect, so make a copy so that we won't overwrite the parent's object.
+  let lastItem = [...nodes].sort(nodesByPosition).pop();
+  if (!lastItem) {
+    throw new Error();
+  }
+  if (syntaxKind) {
+    lastItem = findNodes(lastItem, syntaxKind).sort(nodesByPosition).pop();
+  }
+  if (!lastItem && fallbackPos == undefined) {
+    throw new Error(`tried to insert ${toInsert} as first occurence with no fallback position`);
+  }
+  const lastItemPosition: number = lastItem ? lastItem.getEnd() : fallbackPos;
+
+  return new InsertChange(file, lastItemPosition, toInsert);
+}
+
+
+export function getContentOfKeyLiteral(_source: ts.SourceFile, node: ts.Node): string | null {
+  if (node.kind == ts.SyntaxKind.Identifier) {
+    return (node as ts.Identifier).text;
+  } else if (node.kind == ts.SyntaxKind.StringLiteral) {
+    return (node as ts.StringLiteral).text;
+  } else {
+    return null;
+  }
+}
+
+
+function _angularImportsFromNode(node: ts.ImportDeclaration,
+                                 _sourceFile: ts.SourceFile): {[name: string]: string} {
+  const ms = node.moduleSpecifier;
+  let modulePath: string;
+  switch (ms.kind) {
+    case ts.SyntaxKind.StringLiteral:
+      modulePath = (ms as ts.StringLiteral).text;
+      break;
+    default:
+      return {};
+  }
+
+  if (!modulePath.startsWith('@angular/')) {
+    return {};
+  }
+
+  if (node.importClause) {
+    if (node.importClause.name) {
+      // This is of the form `import Name from 'path'`. Ignore.
+      return {};
+    } else if (node.importClause.namedBindings) {
+      const nb = node.importClause.namedBindings;
+      if (nb.kind == ts.SyntaxKind.NamespaceImport) {
+        // This is of the form `import * as name from 'path'`. Return `name.`.
+        return {
+          [(nb as ts.NamespaceImport).name.text + '.']: modulePath,
+        };
+      } else {
+        // This is of the form `import {a,b,c} from 'path'`
+        const namedImports = nb as ts.NamedImports;
+
+        return namedImports.elements
+          .map((is: ts.ImportSpecifier) => is.propertyName ? is.propertyName.text : is.name.text)
+          .reduce((acc: {[name: string]: string}, curr: string) => {
+            acc[curr] = modulePath;
+
+            return acc;
+          }, {});
+      }
+    }
+
+    return {};
+  } else {
+    // This is of the form `import 'path';`. Nothing to do.
+    return {};
+  }
+}
+
+
+export function getDecoratorMetadata(source: ts.SourceFile, identifier: string,
+                                     module: string): ts.Node[] {
+  const angularImports: {[name: string]: string}
+    = findNodes(source, ts.SyntaxKind.ImportDeclaration)
+    .map((node: ts.ImportDeclaration) => _angularImportsFromNode(node, source))
+    .reduce((acc: {[name: string]: string}, current: {[name: string]: string}) => {
+      for (const key of Object.keys(current)) {
+        acc[key] = current[key];
+      }
+
+      return acc;
+    }, {});
+
+  return getSourceNodes(source)
+    .filter(node => {
+      return node.kind == ts.SyntaxKind.Decorator
+        && (node as ts.Decorator).expression.kind == ts.SyntaxKind.CallExpression;
+    })
+    .map(node => (node as ts.Decorator).expression as ts.CallExpression)
+    .filter(expr => {
+      if (expr.expression.kind == ts.SyntaxKind.Identifier) {
+        const id = expr.expression as ts.Identifier;
+
+        return id.getFullText(source) == identifier
+          && angularImports[id.getFullText(source)] === module;
+      } else if (expr.expression.kind == ts.SyntaxKind.PropertyAccessExpression) {
+        // This covers foo.NgModule when importing * as foo.
+        const paExpr = expr.expression as ts.PropertyAccessExpression;
+        // If the left expression is not an identifier, just give up at that point.
+        if (paExpr.expression.kind !== ts.SyntaxKind.Identifier) {
+          return false;
+        }
+
+        const id = paExpr.name.text;
+        const moduleId = (paExpr.expression as ts.Identifier).getText(source);
+
+        return id === identifier && (angularImports[moduleId + '.'] === module);
+      }
+
+      return false;
+    })
+    .filter(expr => expr.arguments[0]
+                 && expr.arguments[0].kind == ts.SyntaxKind.ObjectLiteralExpression)
+    .map(expr => expr.arguments[0] as ts.ObjectLiteralExpression);
+}
+
+function findClassDeclarationParent(node: ts.Node): ts.ClassDeclaration|undefined {
+  if (ts.isClassDeclaration(node)) {
+    return node;
+  }
+
+  return node.parent && findClassDeclarationParent(node.parent);
+}
+
+/**
+ * Given a source file with @NgModule class(es), find the name of the first @NgModule class.
+ *
+ * @param source source file containing one or more @NgModule
+ * @returns the name of the first @NgModule, or `undefined` if none is found
+ */
+export function getFirstNgModuleName(source: ts.SourceFile): string|undefined {
+  // First, find the @NgModule decorators.
+  const ngModulesMetadata = getDecoratorMetadata(source, 'NgModule', '@angular/core');
+  if (ngModulesMetadata.length === 0) {
+    return undefined;
+  }
+
+  // Then walk parent pointers up the AST, looking for the ClassDeclaration parent of the NgModule
+  // metadata.
+  const moduleClass = findClassDeclarationParent(ngModulesMetadata[0]);
+  if (!moduleClass || !moduleClass.name) {
+    return undefined;
+  }
+
+  // Get the class name of the module ClassDeclaration.
+  return moduleClass.name.text;
+}
+
+export function addSymbolToNgModuleMetadata(
+  source: ts.SourceFile,
+  ngModulePath: string,
+  metadataField: string,
+  symbolName: string,
+  importPath: string | null = null,
+  importText: string | null = null
+): Change[] {
+  const nodes = getDecoratorMetadata(source, 'NgModule', '@angular/core');
+  let node: any = nodes[0];  // tslint:disable-line:no-any
+
+  // Find the decorator declaration.
+  if (!node) {
+    return [];
+  }
+
+  importText = importText || symbolName;
+
+  // Get all the children property assignment of object literals.
+  const matchingProperties: ts.ObjectLiteralElement[] =
+    (node as ts.ObjectLiteralExpression).properties
+    .filter(prop => prop.kind == ts.SyntaxKind.PropertyAssignment)
+    // Filter out every fields that's not "metadataField". Also handles string literals
+    // (but not expressions).
+    .filter((prop: ts.PropertyAssignment) => {
+      const name = prop.name;
+      switch (name.kind) {
+        case ts.SyntaxKind.Identifier:
+          return (name as ts.Identifier).getText(source) == metadataField;
+        case ts.SyntaxKind.StringLiteral:
+          return (name as ts.StringLiteral).text == metadataField;
+      }
+
+      return false;
+    });
+
+  // Get the last node of the array literal.
+  if (!matchingProperties) {
+    return [];
+  }
+  if (matchingProperties.length == 0) {
+    // We haven't found the field in the metadata declaration. Insert a new field.
+    const expr = node as ts.ObjectLiteralExpression;
+    let position: number;
+    let toInsert: string;
+    if (expr.properties.length == 0) {
+      position = expr.getEnd() - 1;
+      toInsert = `  ${metadataField}: [${symbolName}]\n`;
+    } else {
+      node = expr.properties[expr.properties.length - 1];
+      position = node.getEnd();
+      // Get the indentation of the last element, if any.
+      const text = node.getFullText(source);
+      const matches = text.match(/^\r?\n\s*/);
+      if (matches && matches.length > 0) {
+        toInsert = `,${matches[0]}${metadataField}: [${symbolName}]`;
+      } else {
+        toInsert = `, ${metadataField}: [${symbolName}]`;
+      }
+    }
+    if (importPath !== null) {
+      return [
+        new InsertChange(ngModulePath, position, toInsert),
+        insertImport(source, ngModulePath, symbolName.replace(/\..*$/, ''), importPath),
+      ];
+    } else {
+      return [new InsertChange(ngModulePath, position, toInsert)];
+    }
+  }
+  const assignment = matchingProperties[0] as ts.PropertyAssignment;
+
+  // If it's not an array, nothing we can do really.
+  if (assignment.initializer.kind !== ts.SyntaxKind.ArrayLiteralExpression) {
+    return [];
+  }
+
+  const arrLiteral = assignment.initializer as ts.ArrayLiteralExpression;
+  if (arrLiteral.elements.length == 0) {
+    // Forward the property.
+    node = arrLiteral;
+  } else {
+    node = arrLiteral.elements;
+  }
+
+  if (!node) {
+    console.error('No app module found. Please add your new class to your component.');
+
+    return [];
+  }
+
+  if (Array.isArray(node)) {
+    const nodeArray = node as {} as Array<ts.Node>;
+    const symbolsArray = nodeArray.map(node => node.getText());
+    if (symbolsArray.includes(symbolName)) {
+      return [];
+    }
+
+    node = node[node.length - 1];
+  }
+
+  let toInsert: string;
+  let position = node.getEnd();
+  if (node.kind == ts.SyntaxKind.ObjectLiteralExpression) {
+    // We haven't found the field in the metadata declaration. Insert a new
+    // field.
+    const expr = node as ts.ObjectLiteralExpression;
+    if (expr.properties.length == 0) {
+      position = expr.getEnd() - 1;
+      toInsert = `  ${metadataField}: [${importText}]\n`;
+    } else {
+      node = expr.properties[expr.properties.length - 1];
+      position = node.getEnd();
+      // Get the indentation of the last element, if any.
+      const text = node.getFullText(source);
+      if (text.match('^\r?\r?\n')) {
+        toInsert = `,${text.match(/^\r?\n\s+/)[0]}${metadataField}: [${importText}]`;
+      } else {
+        toInsert = `, ${metadataField}: [${importText}]`;
+      }
+    }
+  } else if (node.kind == ts.SyntaxKind.ArrayLiteralExpression) {
+    // We found the field but it's empty. Insert it just before the `]`.
+    position--;
+    toInsert = `${importText}`;
+  } else {
+    // Get the indentation of the last element, if any.
+    const text = node.getFullText(source);
+    if (text.match(/^\r?\n/)) {
+      toInsert = `,${text.match(/^\r?\n(\r?)\s*/)[0]}${importText}`;
+    } else {
+      toInsert = `, ${importText}`;
+    }
+  }
+  if (importPath !== null) {
+    return [
+      new InsertChange(ngModulePath, position, toInsert),
+      insertImport(source, ngModulePath, symbolName.replace(/\..*$/, ''), importPath),
+    ];
+  }
+
+  return [new InsertChange(ngModulePath, position, toInsert)];
+}
+
+/**
+ * Custom function to insert a declaration (component, pipe, directive)
+ * into NgModule declarations. It also imports the component.
+ */
+export function addDeclarationToModule(source: ts.SourceFile,
+                                       modulePath: string, classifiedName: string,
+                                       importPath: string): Change[] {
+  return addSymbolToNgModuleMetadata(
+    source, modulePath, 'declarations', classifiedName, importPath);
+}
+
+/**
+ * Custom function to insert an NgModule into NgModule imports. It also imports the module.
+ */
+export function addImportToModule(source: ts.SourceFile,
+                                  modulePath: string, classifiedName: string,
+                                  importPath: string): Change[] {
+
+  return addSymbolToNgModuleMetadata(source, modulePath, 'imports', classifiedName, importPath);
+}
+
+/**
+ * Custom function to insert a provider into NgModule. It also imports it.
+ */
+export function addProviderToModule(source: ts.SourceFile,
+                                    modulePath: string, classifiedName: string,
+                                    importPath: string): Change[] {
+  return addSymbolToNgModuleMetadata(source, modulePath, 'providers', classifiedName, importPath);
+}
+
+/**
+ * Custom function to insert an export into NgModule. It also imports it.
+ */
+export function addExportToModule(source: ts.SourceFile,
+                                  modulePath: string, classifiedName: string,
+                                  importPath: string): Change[] {
+  return addSymbolToNgModuleMetadata(source, modulePath, 'exports', classifiedName, importPath);
+}
+
+/**
+ * Custom function to insert an export into NgModule. It also imports it.
+ */
+export function addBootstrapToModule(source: ts.SourceFile,
+                                     modulePath: string, classifiedName: string,
+                                     importPath: string): Change[] {
+  return addSymbolToNgModuleMetadata(source, modulePath, 'bootstrap', classifiedName, importPath);
+}
+
+/**
+ * Custom function to insert an entryComponent into NgModule. It also imports it.
+ */
+export function addEntryComponentToModule(source: ts.SourceFile,
+                                          modulePath: string, classifiedName: string,
+                                          importPath: string): Change[] {
+  return addSymbolToNgModuleMetadata(
+    source, modulePath,
+    'entryComponents', classifiedName, importPath,
+  );
+}
+
+/**
+ * Determine if an import already exists.
+ */
+export function isImported(source: ts.SourceFile,
+                           classifiedName: string,
+                           importPath: string): boolean {
+  const allNodes = getSourceNodes(source);
+  const matchingNodes = allNodes
+    .filter(node => node.kind === ts.SyntaxKind.ImportDeclaration)
+    .filter((imp: ts.ImportDeclaration) => imp.moduleSpecifier.kind === ts.SyntaxKind.StringLiteral)
+    .filter((imp: ts.ImportDeclaration) => {
+      return (imp.moduleSpecifier as ts.StringLiteral).text === importPath;
+    })
+    .filter((imp: ts.ImportDeclaration) => {
+      if (!imp.importClause) {
+        return false;
+      }
+      const nodes = findNodes(imp.importClause, ts.SyntaxKind.ImportSpecifier)
+        .filter(n => n.getText() === classifiedName);
+
+      return nodes.length > 0;
+    });
+
+  return matchingNodes.length > 0;
+}

--- a/ngrx/ducks-schematics/src/utils/change.ts
+++ b/ngrx/ducks-schematics/src/utils/change.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export interface Host {
+  write(path: string, content: string): Promise<void>;
+  read(path: string): Promise<string>;
+}
+
+
+export interface Change {
+  apply(host: Host): Promise<void>;
+
+  // The file this change should be applied to. Some changes might not apply to
+  // a file (maybe the config).
+  readonly path: string | null;
+
+  // The order this change should be applied. Normally the position inside the file.
+  // Changes are applied from the bottom of a file to the top.
+  readonly order: number;
+
+  // The description of this change. This will be outputted in a dry or verbose run.
+  readonly description: string;
+}
+
+
+/**
+ * An operation that does nothing.
+ */
+export class NoopChange implements Change {
+  description = 'No operation.';
+  order = Infinity;
+  path = null;
+  apply() { return Promise.resolve(); }
+}
+
+
+/**
+ * Will add text to the source code.
+ */
+export class InsertChange implements Change {
+
+  order: number;
+  description: string;
+
+  constructor(public path: string, public pos: number, public toAdd: string) {
+    if (pos < 0) {
+      throw new Error('Negative positions are invalid');
+    }
+    this.description = `Inserted ${toAdd} into position ${pos} of ${path}`;
+    this.order = pos;
+  }
+
+  /**
+   * This method does not insert spaces if there is none in the original string.
+   */
+  apply(host: Host) {
+    return host.read(this.path).then(content => {
+      const prefix = content.substring(0, this.pos);
+      const suffix = content.substring(this.pos);
+
+      return host.write(this.path, `${prefix}${this.toAdd}${suffix}`);
+    });
+  }
+}
+
+/**
+ * Will remove text from the source code.
+ */
+export class RemoveChange implements Change {
+
+  order: number;
+  description: string;
+
+  constructor(public path: string, private pos: number, private toRemove: string) {
+    if (pos < 0) {
+      throw new Error('Negative positions are invalid');
+    }
+    this.description = `Removed ${toRemove} into position ${pos} of ${path}`;
+    this.order = pos;
+  }
+
+  apply(host: Host): Promise<void> {
+    return host.read(this.path).then(content => {
+      const prefix = content.substring(0, this.pos);
+      const suffix = content.substring(this.pos + this.toRemove.length);
+
+      // TODO: throw error if toRemove doesn't match removed string.
+      return host.write(this.path, `${prefix}${suffix}`);
+    });
+  }
+}
+
+/**
+ * Will replace text from the source code.
+ */
+export class ReplaceChange implements Change {
+  order: number;
+  description: string;
+
+  constructor(public path: string, private pos: number, private oldText: string,
+              private newText: string) {
+    if (pos < 0) {
+      throw new Error('Negative positions are invalid');
+    }
+    this.description = `Replaced ${oldText} into position ${pos} of ${path} with ${newText}`;
+    this.order = pos;
+  }
+
+  apply(host: Host): Promise<void> {
+    return host.read(this.path).then(content => {
+      const prefix = content.substring(0, this.pos);
+      const suffix = content.substring(this.pos + this.oldText.length);
+      const text = content.substring(this.pos, this.pos + this.oldText.length);
+
+      if (text !== this.oldText) {
+        return Promise.reject(new Error(`Invalid replace: "${text}" != "${this.oldText}".`));
+      }
+
+      // TODO: throw error if oldText doesn't match removed string.
+      return host.write(this.path, `${prefix}${this.newText}${suffix}`);
+    });
+  }
+}

--- a/ngrx/ducks-schematics/src/utils/find-modules.ts
+++ b/ngrx/ducks-schematics/src/utils/find-modules.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { dirname, join, normalize, NormalizedRoot, Path, relative } from '@angular-devkit/core';
+import { DirEntry, Tree } from '@angular-devkit/schematics';
+
+
+export interface ModuleOptions {
+  module?: string;
+  name: string;
+  flat?: boolean;
+  path?: string;
+  skipImport?: boolean;
+  moduleExt?: string;
+  routingModuleExt?: string;
+}
+
+const MODULE_EXT = '.module.ts';
+const ROUTING_MODULE_EXT = '-routing.module.ts';
+
+/**
+ * Find the module referred by a set of options passed to the schematics.
+ */
+export function findModuleFromOptions(host: Tree, options: ModuleOptions): Path | undefined {
+  if (options.hasOwnProperty('skipImport') && options.skipImport) {
+    return undefined;
+  }
+
+  const moduleExt = options.moduleExt || MODULE_EXT;
+  const routingModuleExt = options.routingModuleExt || ROUTING_MODULE_EXT;
+
+  if (!options.module) {
+    const pathToCheck = (options.path || '') + '/' + options.name;
+
+    return normalize(findModule(host, pathToCheck, moduleExt, routingModuleExt));
+  } else {
+    const modulePath = normalize(`/${options.path}/${options.module}`);
+    const componentPath = normalize(`/${options.path}/${options.name}`);
+    const moduleBaseName = normalize(modulePath).split('/').pop();
+
+    const candidateSet = new Set<Path>([
+      normalize(options.path || '/'),
+    ]);
+
+    for (let dir = modulePath; dir != NormalizedRoot; dir = dirname(dir)) {
+      candidateSet.add(dir);
+    }
+    for (let dir = componentPath; dir != NormalizedRoot; dir = dirname(dir)) {
+      candidateSet.add(dir);
+    }
+
+    const candidatesDirs = [...candidateSet].sort((a, b) => b.length - a.length);
+    for (const c of candidatesDirs) {
+      const candidateFiles = [
+        '',
+        `${moduleBaseName}.ts`,
+        `${moduleBaseName}${moduleExt}`,
+      ].map(x => join(c, x));
+
+      for (const sc of candidateFiles) {
+        if (host.exists(sc)) {
+          return normalize(sc);
+        }
+      }
+    }
+
+    throw new Error(
+      `Specified module '${options.module}' does not exist.\n`
+        + `Looked in the following directories:\n    ${candidatesDirs.join('\n    ')}`,
+    );
+  }
+}
+
+/**
+ * Function to find the "closest" module to a generated file's path.
+ */
+export function findModule(host: Tree, generateDir: string,
+                           moduleExt = MODULE_EXT, routingModuleExt = ROUTING_MODULE_EXT): Path {
+
+  let dir: DirEntry | null = host.getDir('/' + generateDir);
+  let foundRoutingModule = false;
+
+  while (dir) {
+    const allMatches = dir.subfiles.filter(p => p.endsWith(moduleExt));
+    const filteredMatches = allMatches.filter(p => !p.endsWith(routingModuleExt));
+
+    foundRoutingModule = foundRoutingModule || allMatches.length !== filteredMatches.length;
+
+    if (filteredMatches.length == 1) {
+      return join(dir.path, filteredMatches[0]);
+    } else if (filteredMatches.length > 1) {
+      throw new Error('More than one module matches. Use skip-import option to skip importing '
+        + 'into the closest module.');
+    }
+
+    dir = dir.parent;
+  }
+
+  const errorMsg = foundRoutingModule ? 'Could not find a non Routing NgModule.'
+    + `\nModules with suffix '${routingModuleExt}' are strictly reserved for routing.`
+    + '\nUse the skip-import option to skip importing in NgModule.'
+    : 'Could not find an NgModule. Use the skip-import option to skip importing in NgModule.';
+
+  throw new Error(errorMsg);
+}
+
+/**
+ * Build a relative path from one file path to another file path.
+ */
+export function buildRelativePath(from: string, to: string): string {
+  from = normalize(from);
+  to = normalize(to);
+
+  // Convert to arrays.
+  const fromParts = from.split('/');
+  const toParts = to.split('/');
+
+  // Remove file names (preserving destination)
+  fromParts.pop();
+  const toFileName = toParts.pop();
+
+  const relativePath = relative(normalize(fromParts.join('/') || '/'),
+   normalize(toParts.join('/') || '/'));
+  let pathPrefix = '';
+
+  // Set the path prefix for same dir or child dir, parent dir starts with `..`
+  if (!relativePath) {
+    pathPrefix = '.';
+  } else if (!relativePath.startsWith('.')) {
+    pathPrefix = `./`;
+  }
+  if (pathPrefix && !pathPrefix.endsWith('/')) {
+    pathPrefix += '/';
+  }
+
+  return pathPrefix + (relativePath ? relativePath + '/' : '') + toFileName;
+}


### PR DESCRIPTION
Hi there! 

This adds the option `effects` to the `duck` schematic (default: `true`).

When turned on, it will create a `<duck name>.effects.ts` file including the basic setup of the effects class.
I also added a prompt for it + I added a prompt for the `barrel` option.

Can you review @GregOnNet?

ps: I want to add the possibility for selectors too, but within a separate pr.
**edit**: added the selectors option here too